### PR TITLE
Fixed error with multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Role Variables
 ```
 loggly:
   tags: ''
-  token: ''
+  token:
+    - ansible
+    - syslog-ng
 ```
 
-Loggly tags can be multiple tags, comma-separated.
+Loggly tags is list of multiple tags.
 Loggly token variable is your Loggly account token.
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 loggly:
   tags: ''
-  token: ''
+  token: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,4 @@ galaxy_info:
   - system
   - web
   - monitoring
+dependencies: []

--- a/templates/22-default.conf.j2
+++ b/templates/22-default.conf.j2
@@ -1,10 +1,11 @@
-template LogglyFormatDefault { template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} ${MSGID} [{{ loggly.token }}@41058 tag=\"{{ loggly.tags }}\"] $MSG\n");
+
+template LogglyFormatDefault { template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} ${MSGID} [{{ loggly.token }}@41058 tag=\"{{ loggly.tags | join("\\\" tag=\\\"") }}\"] $MSG\n");
 	template_escape(no);
 };
 
 destination d_loggly {
-        tcp("logs-01.loggly.com" port(6514) 
-        tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/keys/ca.d/')) 
+        tcp("logs-01.loggly.com" port(6514)
+        tls(peer-verify(required-untrusted) ca_dir('/etc/syslog-ng/keys/ca.d/'))
         template(LogglyFormatDefault));
 };
 


### PR DESCRIPTION
Syslog-ng were sending all tags in one comma separated list. Loggly were sending "InvalidTags" notification. Updated template to create separate "tag=" for each tag.

Also added empty "dependencies" to meta.yml because otherwise `ansible-galaxy` throw error.