### PR TITLE
Fixed "No such file or directory" error when combining certifcates

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 
 - name: combine loggly certificates and place in correct folder
   sudo: true
-  raw: cat {/tmp/sf_bundle.crt,/tmp/loggly.com.crt} > /etc/syslog-ng/keys/ca.d/loggly_full.crt
+  raw: cat /tmp/sf_bundle.crt > /etc/syslog-ng/keys/ca.d/loggly_full.crt && cat /tmp/loggly.com.crt >> /etc/syslog-ng/keys/ca.d/loggly_full.crt
 
 - name: default syslog-ng template
   sudo: true


### PR DESCRIPTION
The "combine loggly certificates and place in correct folder" task
were failing to error "No such file or directory".
Changed the command to more simple command.

Not sure what the root cause but I can reproduce the error from command line:
```shell
# sh -c "cat {/tmp/sf_bundle.crt,/tmp/loggly.com.crt}"
cat: {/tmp/sf_bundle.crt,/tmp/loggly.com.crt}: No such file or directory
```